### PR TITLE
re-use formatted tag strings

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+## Unreleased
+
+* [@erulabs](https://github.com/erulabs) Reuse formatted tag strings in `overrideTags` to avoid splitting and reconstructing values, while preserving tag sanitization, overrides, and duplicate-key ordering.
+
 ## 17.1.0 (2026-7-25)
 
 * [@bdeitte](https://github.com/bdeitte) Parse whitespace-delimited `DD_TAGS` / `DATADOG_TAGS` values: when the value contains no comma, whitespace is used as the separator, matching `dd-trace-js` and the Datadog Agent. See [#325](https://github.com/bdeitte/hot-shots/issues/325)

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -107,11 +107,10 @@ function overrideTags (parent, child, telegraf) {
       toAppend.push(tag);
     } else {
       const key = tag.substring(0, idx);
-      const value = tag.substring(idx + 1);
       if (!childCopy.has(key)) {
         childCopy.set(key, []);
       }
-      childCopy.get(key).push(value);
+      childCopy.get(key).push(tag);
     }
   });
 
@@ -124,9 +123,9 @@ function overrideTags (parent, child, telegraf) {
     return !childCopy.has(key);
   });
 
-  for (const [key, values] of childCopy) {
-    for (const value of values) {
-      result.push(`${key}:${value}`);
+  for (const tags of childCopy.values()) {
+    for (const tag of tags) {
+      result.push(tag);
     }
   }
   result.push(...toAppend);

--- a/perfTest/test.js
+++ b/perfTest/test.js
@@ -44,6 +44,14 @@ bench('increment, per-metric tags (no overlap)',
 bench('increment, per-metric + global tags (overlap)',
   () => globalTagClient.increment('hot.shots.perf.metric', 1, { env: 'staging', version: 'v2' }));
 
+bench('increment, per-metric array tags',
+  () => noTagClient.increment('hot.shots.perf.metric', 1,
+    ['app:api', 'env:prod', 'queryName:Teacher.findOne']));
+
+bench('increment, interleaved duplicate array tags',
+  () => globalTagClient.increment('hot.shots.perf.metric', 1,
+    ['env:staging', 'url:https://example.com:8443', 'env:canary']));
+
 bench('timing',
   () => noTagClient.timing('hot.shots.perf.metric', 250));
 

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -505,6 +505,42 @@ describe('#helpersExtended', () => {
       });
     });
 
+    [false, true].forEach(telegraf => {
+      describe(telegraf ? 'Telegraf tag grouping' : 'StatsD tag grouping', () => {
+        it('preserves grouped order for interleaved duplicates, bare tags and colon-containing values', () => {
+          const parent = Object.freeze(['url:old', 'env:prod', 'service:api', 'url:older']);
+          const child = Object.freeze([
+            'url:https://example.com:8443/a', 'bare', 'env:dev',
+            'url:', 'env:staging', 'url:https://example.com:443/b', ':leading'
+          ]);
+
+          const result = helpers.overrideTags(parent, child, telegraf);
+
+          assert.deepStrictEqual(result, [
+            'service:api',
+            'url:https://example.com:8443/a', 'url:', 'url:https://example.com:443/b',
+            'env:dev', 'env:staging', 'bare', '_leading'
+          ]);
+        });
+
+        it('groups object keys that collide after sanitization without losing values', () => {
+          const parent = Object.freeze(['key_:old', 'service:api']);
+          const child = Object.freeze({
+            'key|': 'https://example.com:8443/a|b',
+            env: 'dev',
+            'key,': '',
+            'key_': 'second:value'
+          });
+
+          const result = helpers.overrideTags(parent, child, telegraf);
+
+          assert.deepStrictEqual(result, [
+            'service:api', 'key_:https://example.com:8443/a_b', 'key_:', 'key_:second:value', 'env:dev'
+          ]);
+        });
+      });
+    });
+
     describe('Mixed scenarios and edge cases', () => {
       it('should handle empty parent with array child', () => {
         const parent = [];


### PR DESCRIPTION
At classdojo.com, production profiling showed overrideTags accounting for roughly 2% of active CPU samples in a busy API container. It was splitting already-formatted tags into keys and values, then rebuilding the same strings.

This change reuses those strings while preserving sanitization, overrides, duplicates, and ordering. Local benchmarks show 11–16% less time spent in the helper.

Added regression tests and benchmark cases. All 1,967 tests pass on Node 24, and 24,000 generated equivalence checks match the original implementation.